### PR TITLE
CS Fixer on commit

### DIFF
--- a/bin/build-hook
+++ b/bin/build-hook
@@ -5,8 +5,9 @@ function real_path { echo $(cd $(dirname $1); pwd)/$(basename $1); }
 from=$(real_path ./bin/pre-commit)
 target=$(real_path ./.git/hooks/pre-commit)
 
-unlink ${target}
-
-#if [ ! -f ${target} ]; then
+if [ ! -f ${target} ]; then
   ln -s ${from} ${target}
-#fi
+fi
+
+# Configure attribute
+git config filter.phpcsfixer.clean ./bin/filters/clean.php

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -41,8 +41,15 @@ do
   # May want to add support for specifying PHP path
   # Tosses out regular output, we only care about errors.
   currLint=`php -l ${entry} 2>&1 1>/dev/null`
+  # Check for Linting issues.
   if [[ ${#currLint} == 0 ]]; then
     ((filesPassed++))
+    if exists php-cs-fixer ; then
+      # Run CS Fixer
+      php-cs-fixer fix ${entry} 2>&1 1>/dev/null
+      # Remove empty change.
+      git checkout -- ${entry}
+    fi
   else
     echo -e "Failed: ${entry}" | error
     echo -e "${currLint}\n" | error

--- a/src/Monitoring.php
+++ b/src/Monitoring.php
@@ -7,7 +7,7 @@ use Throwable;
 
 /**
  * Backed by the newrelic PHP extension,
- * gracefully degrades to no-op when it's not present...
+ * gracefully degrades to no-op when it's not present.
  */
 class Monitoring
 {


### PR DESCRIPTION
@elrossco22 @giorgiosironi 

So what happens here is the attribute kicks off when you stage a file, and it fixes the code style in the staged copy. Once you commit, it will update your local copy with the style fixes. I have to run a clean on the files that had updates since there is a "no changes" in the working copy that is deceiving. 

Hopefully this can cut down on the broken builds.