### PR TITLE
Bug fix: does not remove elements from the queue

### DIFF
--- a/src/Command/QueueCommand.php
+++ b/src/Command/QueueCommand.php
@@ -103,6 +103,7 @@ abstract class QueueCommand extends Command
             if ($entity = $this->transform($item)) {
                 $this->process($input, $item, $entity);
             }
+            $this->queue->commit($item);
             $this->monitoring->endTransaction();
         }
         $this->logger->debug($this->getName().' End of loop');

--- a/src/Queue/Mock/WatchableQueueMock.php
+++ b/src/Queue/Mock/WatchableQueueMock.php
@@ -32,7 +32,7 @@ final class WatchableQueueMock implements WatchableQueue
     public function dequeue()
     {
         if ($this->items === []) {
-            throw new LogicException("You should not reach a dequeue() on an empty queue inside tests");
+            throw new LogicException('You should not reach a dequeue() on an empty queue inside tests');
         }
         $item = array_pop($this->items);
 

--- a/src/Queue/Mock/WatchableQueueMock.php
+++ b/src/Queue/Mock/WatchableQueueMock.php
@@ -4,11 +4,12 @@ namespace eLife\Bus\Queue\Mock;
 
 use eLife\Bus\Queue\QueueItem;
 use eLife\Bus\Queue\WatchableQueue;
+use LogicException;
 
 final class WatchableQueueMock implements WatchableQueue
 {
     private $items = [];
-    private $process = [];
+    private $invisibleItems = [];
 
     public function __construct(QueueItem ...$items)
     {
@@ -30,9 +31,12 @@ final class WatchableQueueMock implements WatchableQueue
      */
     public function dequeue()
     {
+        if ($this->items === []) {
+            throw new LogicException("You should not reach a dequeue() on an empty queue inside tests");
+        }
         $item = array_pop($this->items);
 
-        return $this->process[$item->getReceipt()] = $item;
+        return $this->invisibleItems[$item->getReceipt()] = $item;
     }
 
     /**
@@ -40,7 +44,7 @@ final class WatchableQueueMock implements WatchableQueue
      */
     public function commit(QueueItem $item)
     {
-        unset($this->process[$item->getReceipt()]);
+        unset($this->invisibleItems[$item->getReceipt()]);
     }
 
     /**
@@ -60,7 +64,7 @@ final class WatchableQueueMock implements WatchableQueue
 
     public function count() : int
     {
-        return count($this->items);
+        return count($this->items) + count($this->invisibleItems);
     }
 
     public function __toString() : string

--- a/tests/src/Command/QueueCommandTest.php
+++ b/tests/src/Command/QueueCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace eLife\Bus\Command;
+
+use eLife\Bus\Monitoring;
+use eLife\Bus\Queue\Mock\WatchableQueueMock;
+use eLife\Bus\Queue\QueueItem;
+use eLife\Bus\Queue\InternalSqsMessage;
+use eLife\Bus\Queue\QueueItemTransformer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class QueueCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->queue = new WatchableQueueMock();
+        $this->command = new ApplicationSpecificQueueCommand(
+            $this->createMock(LoggerInterface::class),
+            $this->queue,
+            $this->createMock(QueueItemTransformer::class),
+            new Monitoring(),
+            $this->limitIterations(1)
+        );
+        $this->input = $this->createMock(InputInterface::class);
+        $this->output = $this->createMock(OutputInterface::class);
+    }
+
+    public function testDeletesMessagesFromTheQueueAfterProcessing()
+    {
+        $message = new InternalSqsMessage('article', '42');
+        $this->queue->enqueue($message);
+        $this->command->execute($this->input, $this->output);
+        $this->assertEquals(0, $this->queue->count(), "Expected an empty queue");
+    }
+
+    private function limitIterations($number)
+    {
+        $this->iterationCounter = 0;
+        return function() use ($number) {
+            $this->iterationCounter++;
+            if ($this->iterationCounter > $number) {
+                return true;
+            }
+
+            return false;
+        };
+    }
+}
+
+class ApplicationSpecificQueueCommand extends QueueCommand
+{
+    protected function process(InputInterface $input, QueueItem $item, $entity = null)
+    {
+    }
+}
+

--- a/tests/src/Command/QueueCommandTest.php
+++ b/tests/src/Command/QueueCommandTest.php
@@ -3,9 +3,9 @@
 namespace eLife\Bus\Command;
 
 use eLife\Bus\Monitoring;
+use eLife\Bus\Queue\InternalSqsMessage;
 use eLife\Bus\Queue\Mock\WatchableQueueMock;
 use eLife\Bus\Queue\QueueItem;
-use eLife\Bus\Queue\InternalSqsMessage;
 use eLife\Bus\Queue\QueueItemTransformer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,14 +32,15 @@ class QueueCommandTest extends \PHPUnit_Framework_TestCase
         $message = new InternalSqsMessage('article', '42');
         $this->queue->enqueue($message);
         $this->command->execute($this->input, $this->output);
-        $this->assertEquals(0, $this->queue->count(), "Expected an empty queue");
+        $this->assertEquals(0, $this->queue->count(), 'Expected an empty queue');
     }
 
     private function limitIterations($number)
     {
         $this->iterationCounter = 0;
-        return function() use ($number) {
-            $this->iterationCounter++;
+
+        return function () use ($number) {
+            ++$this->iterationCounter;
             if ($this->iterationCounter > $number) {
                 return true;
             }
@@ -55,4 +56,3 @@ class ApplicationSpecificQueueCommand extends QueueCommand
     {
     }
 }
-


### PR DESCRIPTION
So queue:watch commands continue to process the same items over and over. Only recommendations is affected