### PR TITLE
Utility commands to use in search and recommendations

### DIFF
--- a/src/Command/QueueCleanCommand.php
+++ b/src/Command/QueueCleanCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eLife\Bus\Command;
+
+use eLife\Bus\Queue\WatchableQueue;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class QueueCleanCommand extends Command
+{
+    private $queue;
+    private $logger;
+
+    public function __construct(WatchableQueue $queue, LoggerInterface $logger)
+    {
+        $this->queue = $queue;
+        $this->logger = $logger;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('queue:clean')
+            ->setDescription('Cleans the SQS queue through purging. Asynchronous.');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->logger->info('Cleaning queue: '.$this->queue->__toString());
+        $output->writeln($this->queue->count());
+    }
+}

--- a/src/Command/QueueCountCommand.php
+++ b/src/Command/QueueCountCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace eLife\Bus\Command;
+
+use eLife\Bus\Queue\WatchableQueue;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class QueueCountCommand extends Command
+{
+    private $queue;
+
+    public function __construct(WatchableQueue $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('queue:count')
+            ->setDescription('Counts the SQS messages, including invisible ones. Approximate.');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln($this->queue->count());
+    }
+}


### PR DESCRIPTION
There are possibly more, but these are the ones strictly necessary to automate the `ci-import` execution.