### PR TITLE
Relax requirement of Symfony Console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,15 @@
         "elife/logging-sdk": "dev-master",
         "aws/aws-sdk-php": "^3.19",
         "jms/serializer": "^1.4",
-        "psr/log": "1.0.*",
-        "symfony/console": "^3.2",
-        "doctrine/cache": "^1.6"
+        "doctrine/cache": "^1.6",
+        "psr/log": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "symfony/console": "^3.2"
+    },
+    "suggest": {
+        "symfony/console": "To use Command classes"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows to reuse the MemoryLimit class in Drupal, where Symfony Console is required to be some other conflicting version