### PR TITLE
Renamed Limit::__invoke() to Limit::hasBeenReached(), step 1

### DIFF
--- a/src/Limit/CallbackLimit.php
+++ b/src/Limit/CallbackLimit.php
@@ -21,6 +21,8 @@ final class CallbackLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/CallbackLimit.php
+++ b/src/Limit/CallbackLimit.php
@@ -11,9 +11,17 @@ final class CallbackLimit implements Limit
         $this->callback = $callback;
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         return call_user_func($this->callback);
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/src/Limit/CompositeLimit.php
+++ b/src/Limit/CompositeLimit.php
@@ -5,20 +5,20 @@ namespace eLife\Bus\Limit;
 final class CompositeLimit implements Limit
 {
     private $reasons = [];
-    private $functions = [];
+    private $limits = [];
 
     public function __construct(Limit ...$args)
     {
-        $this->functions = $args;
+        $this->limits = $args;
     }
 
     public function hasBeenReached() : bool
     {
         $limitReached = false;
-        foreach ($this->functions as $fn) {
-            $failure = $fn();
+        foreach ($this->limits as $limit) {
+            $failure = $limit->hasBeenReached();
             if ($failure) {
-                $this->reasons = array_merge($this->reasons, $fn->getReasons());
+                $this->reasons = array_merge($this->reasons, $limit->getReasons());
                 $limitReached = true;
             }
         }

--- a/src/Limit/CompositeLimit.php
+++ b/src/Limit/CompositeLimit.php
@@ -31,6 +31,8 @@ final class CompositeLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/CompositeLimit.php
+++ b/src/Limit/CompositeLimit.php
@@ -12,7 +12,7 @@ final class CompositeLimit implements Limit
         $this->functions = $args;
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         $limitReached = false;
         foreach ($this->functions as $fn) {
@@ -24,6 +24,14 @@ final class CompositeLimit implements Limit
         }
 
         return $limitReached;
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/src/Limit/Limit.php
+++ b/src/Limit/Limit.php
@@ -4,6 +4,11 @@ namespace eLife\Bus\Limit;
 
 interface Limit
 {
+    public function hasBeenReached() : bool;
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
     public function __invoke() : bool;
 
     public function getReasons() : array;

--- a/src/Limit/LoggingLimit.php
+++ b/src/Limit/LoggingLimit.php
@@ -18,10 +18,9 @@ final class LoggingLimit implements Limit
 
     public function hasBeenReached() : bool
     {
-        $limit = $this->limit;
-        $limitReached = $limit();
+        $limitReached = $this->limit->hasBeenReached();
         if ($limitReached) {
-            $this->reasons = $limit->getReasons();
+            $this->reasons = $this->limit->getReasons();
             foreach ($this->reasons as $reason) {
                 $this->logger->info($reason);
             }

--- a/src/Limit/LoggingLimit.php
+++ b/src/Limit/LoggingLimit.php
@@ -16,7 +16,7 @@ final class LoggingLimit implements Limit
         $this->logger = $logger;
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         $limit = $this->limit;
         $limitReached = $limit();
@@ -28,6 +28,14 @@ final class LoggingLimit implements Limit
         }
 
         return $limitReached;
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/src/Limit/LoggingLimit.php
+++ b/src/Limit/LoggingLimit.php
@@ -35,6 +35,8 @@ final class LoggingLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/MemoryLimit.php
+++ b/src/Limit/MemoryLimit.php
@@ -32,6 +32,8 @@ final class MemoryLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/MemoryLimit.php
+++ b/src/Limit/MemoryLimit.php
@@ -17,7 +17,7 @@ final class MemoryLimit implements Limit
         return new self($megabytes * 1024 * 1024);
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         $this->actualBytes = memory_get_usage(true);
         if ($this->actualBytes > $this->bytes) {
@@ -25,6 +25,14 @@ final class MemoryLimit implements Limit
         }
 
         return false;
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/src/Limit/MockLimit.php
+++ b/src/Limit/MockLimit.php
@@ -28,6 +28,8 @@ final class MockLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/MockLimit.php
+++ b/src/Limit/MockLimit.php
@@ -18,9 +18,17 @@ final class MockLimit implements Limit
         $this->messages = $messages;
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         return $this->fail;
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/src/Limit/SignalsLimit.php
+++ b/src/Limit/SignalsLimit.php
@@ -39,6 +39,8 @@ final class SignalsLimit implements Limit
      */
     public function __invoke() : bool
     {
+        error_log('Using '.__CLASS__.' as a callable is deprecated. Use CallbackLimit:: hasBeenReached() instead.', E_USER_ERROR);
+
         return $this->hasBeenReached();
     }
 

--- a/src/Limit/SignalsLimit.php
+++ b/src/Limit/SignalsLimit.php
@@ -27,11 +27,19 @@ final class SignalsLimit implements Limit
         return new static($signals);
     }
 
-    public function __invoke() : bool
+    public function hasBeenReached() : bool
     {
         pcntl_signal_dispatch();
 
         return $this->valid === false;
+    }
+
+    /**
+     * @deprecated  use hasBeenReached() instead
+     */
+    public function __invoke() : bool
+    {
+        return $this->hasBeenReached();
     }
 
     public function getReasons() : array

--- a/test/src/Limit/CompositeLimitTest.php
+++ b/test/src/Limit/CompositeLimitTest.php
@@ -14,7 +14,7 @@ final class CompositeLimitTest extends TestCase
         $pass = new MockLimit();
         $limit = new CompositeLimit($fail, $pass);
 
-        $this->assertTrue($limit());
+        $this->assertTrue($limit->hasBeenReached());
 
         $this->assertEquals(['This is the reason it failed'], $limit->getReasons());
     }
@@ -27,7 +27,7 @@ final class CompositeLimitTest extends TestCase
         $pass = new MockLimit();
         $limit = new CompositeLimit($fail, $fail2, $fail3, $pass);
 
-        $this->assertTrue($limit());
+        $this->assertTrue($limit->hasBeenReached());
 
         $this->assertEquals([
             'failure 1',
@@ -43,7 +43,7 @@ final class CompositeLimitTest extends TestCase
         $pass2 = new MockLimit();
         $limit = new CompositeLimit($pass, $pass2);
 
-        $this->assertFalse($limit());
+        $this->assertFalse($limit->hasBeenReached());
 
         $this->assertEquals([], $limit->getReasons());
     }

--- a/test/src/Limit/LoggingLimitTest.php
+++ b/test/src/Limit/LoggingLimitTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace test\eLife\Bus\Limit;
+
+use eLife\Bus\Limit\LoggingLimit;
+use eLife\Bus\Limit\MockLimit;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class LoggingLimitTest extends TestCase
+{
+    public function test_logging_reasons()
+    {
+        $fail = new MockLimit(true);
+        $logger = $this->createMock(LoggerInterface::class);
+        $limit = new LoggingLimit($fail, $logger);
+
+        $logger->expects($this->once())
+            ->method('info')
+            ->with('This is the reason it failed');
+        $this->assertTrue($limit->hasBeenReached());
+        $this->assertEquals(['This is the reason it failed'], $limit->getReasons());
+    }
+}


### PR DESCRIPTION
The use of objects which are callables lead to non-intuitive behavior of Dependency Injection Containers like Pimple:
https://github.com/nlisgo/annotations-silex/commit/8e8e584422c7fb7e94f26e4b2e707420a11204bd
To avoid the corner cases, we can transform them dropping the callable interface. We were already going into this direction when introducing the `Limit` interface and enforcing a type hint stricter than callable.