### PR TITLE
Unify exception management in QueueCommand

### DIFF
--- a/src/Command/QueueCommand.php
+++ b/src/Command/QueueCommand.php
@@ -81,15 +81,6 @@ abstract class QueueCommand extends Command
             ]);
             // Remove from queue.
             $this->queue->commit($item);
-        } catch (Throwable $e) {
-            // Unknown error.
-            $this->logger->error("{$this->getName()}: There was an unknown problem transforming {$item->getType()} ({$item->getId()})", [
-                'exception' => $e,
-                'item' => $item,
-            ]);
-            $this->monitoring->recordException($e, "Error in importing {$item->getType()} {$item->getId()}");
-            // Remove from queue.
-            $this->queue->commit($item);
         }
 
         return $entity;

--- a/src/Command/QueueCommand.php
+++ b/src/Command/QueueCommand.php
@@ -83,7 +83,7 @@ abstract class QueueCommand extends Command
             $this->queue->commit($item);
         } catch (Throwable $e) {
             // Unknown error.
-            $this->logger->error("{$this->getName()}: There was an unknown problem importing {$item->getType()} ({$item->getId()})", [
+            $this->logger->error("{$this->getName()}: There was an unknown problem transforming {$item->getType()} ({$item->getId()})", [
                 'exception' => $e,
                 'item' => $item,
             ]);

--- a/src/Command/QueueCommand.php
+++ b/src/Command/QueueCommand.php
@@ -92,7 +92,6 @@ abstract class QueueCommand extends Command
                     'exception' => $e,
                     'item' => $item,
                 ]);
-                //$this->queue->commit($item);
             } catch (Throwable $e) {
                 $this->logger->error("{$this->getName()}: There was an unknown problem processing {$item->getType()} ({$item->getId()})", [
                     'exception' => $e,

--- a/src/Queue/Mock/WatchableQueueMock.php
+++ b/src/Queue/Mock/WatchableQueueMock.php
@@ -44,6 +44,9 @@ final class WatchableQueueMock implements WatchableQueue
      */
     public function commit(QueueItem $item)
     {
+        if (!array_key_exists($item->getReceipt(), $this->invisibleItems)) {
+            throw new LogicException("Item {$item->getReceipt()} has already been committed and removed from the queue");
+        }
         unset($this->invisibleItems[$item->getReceipt()]);
     }
 

--- a/src/Queue/Mock/WatchableQueueMock.php
+++ b/src/Queue/Mock/WatchableQueueMock.php
@@ -50,16 +50,6 @@ final class WatchableQueueMock implements WatchableQueue
         unset($this->invisibleItems[$item->getReceipt()]);
     }
 
-    /**
-     * Mock: re-add to queue.
-     */
-    public function release(QueueItem $item) : bool
-    {
-        array_unshift($this->items, $item);
-
-        return true;
-    }
-
     public function clean()
     {
         $this->items = [];

--- a/src/Queue/SqsWatchableQueue.php
+++ b/src/Queue/SqsWatchableQueue.php
@@ -64,24 +64,6 @@ final class SqsWatchableQueue implements WatchableQueue
         ]);
     }
 
-    /**
-     * This will happen when an error happens, we release the item back into the queue.
-     */
-    public function release(QueueItem $item) : bool
-    {
-        try {
-            $this->client->changeMessageVisibility([
-                'QueueUrl' => $this->url,
-                'ReceiptHandle' => $item->getReceipt(),
-                'VisibilityTimeout' => 0,
-            ]);
-        } catch (Throwable $e) {
-            return false;
-        }
-
-        return true;
-    }
-
     public function clean()
     {
         $this->client->purgeQueue([

--- a/src/Queue/WatchableQueue.php
+++ b/src/Queue/WatchableQueue.php
@@ -24,11 +24,6 @@ interface WatchableQueue extends Countable
     public function commit(QueueItem $item);
 
     /**
-     * This will happen when an error happens, we release the item back into the queue.
-     */
-    public function release(QueueItem $item) : bool;
-
-    /**
      * Deletes everything from the queue.
      */
     public function clean();

--- a/test/src/Command/QueueCommandTest.php
+++ b/test/src/Command/QueueCommandTest.php
@@ -93,7 +93,7 @@ final class QueueCommandTest extends TestCase
         $this->logger
             ->expects($this->once())
             ->method('error')
-            ->with('queue:watch: There was an unknown problem transforming article (42)', ['exception' => new Exception('Unknown type of entity'), 'item' => new InternalSqsMessage('article', '42')]);
+            ->with('queue:watch: There was an unknown problem processing article (42)', ['exception' => new Exception('Unknown type of entity'), 'item' => new InternalSqsMessage('article', '42')]);
         $command_tester = new CommandTester($this->application->get($command->getName()));
         $command_tester->execute(['command' => $command->getName()]);
         $this->assertEquals(0, $this->queue->count(), 'Expected an empty queue');


### PR DESCRIPTION
- Full coverage for `QueueCommand`
- Put all `catch()` blocks in a single place and deduplicate them
- Use `finally` to ensure `commit()` call happens
- Avoid multiple `commit()` calls in any scenario
- Remove dead `release()` method