### PR TITLE
Move naming of transaction inside it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "phpunit/phpunit": "^5.7.1 || ^6.0",
         "symfony/console": "^2.7 || ^3.2"
     },
+    "conflict": {
+        "sebastian/comparator": "<1.2.3"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "suggest": {

--- a/src/Command/QueueCommand.php
+++ b/src/Command/QueueCommand.php
@@ -59,7 +59,6 @@ abstract class QueueCommand extends Command
     final public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->logger->info($this->getName().' Started listening.');
-        $this->monitoring->nameTransaction($this->getName());
         while (!$this->limit->hasBeenReached()) {
             $this->loop($input);
         }
@@ -100,6 +99,7 @@ abstract class QueueCommand extends Command
         $item = $this->queue->dequeue();
         if ($item) {
             $this->monitoring->startTransaction();
+            $this->monitoring->nameTransaction($this->getName());
             if ($entity = $this->transform($item)) {
                 try {
                     $this->process($input, $item, $entity);


### PR DESCRIPTION
According to https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_name_transaction this must be called inside a transaction.